### PR TITLE
Server setup and address error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ const app = express();
 
 // 포트 설정 - 프테로닥틸은 SERVER_PORT를 사용
 const PORT = process.env.SERVER_PORT || process.env.PORT || 3000;
-const HOST = process.env.SERVER_IP || process.env.HOST || '0.0.0.0';
+// 프테로닥틸 환경에서는 항상 0.0.0.0으로 바인딩해야 함
+const HOST = '0.0.0.0';
 
 // 사이트 설정
 const SITE_URL = process.env.SITE_URL || `http://localhost:${PORT}`;


### PR DESCRIPTION
Fixes `EADDRNOTAVAIL` error by forcing server to bind to `0.0.0.0` in container environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ceb3f8e-9ce7-4c79-b191-bc53b3e1eafb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ceb3f8e-9ce7-4c79-b191-bc53b3e1eafb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

